### PR TITLE
Use exec instead of backtick in `bin/remote exec`

### DIFF
--- a/templates/bin/remote.tt
+++ b/templates/bin/remote.tt
@@ -37,7 +37,7 @@ class CLI < Thor
     invoke :configure, []
     task_arn = find_task_arn
 
-    `aws ecs execute-command #{exec_command_args(task_arn, command).join(' ')}`
+    Kernel.exec "aws ecs execute-command #{exec_command_args(task_arn, command).join(' ')}"
   end
 
   desc 'configure', 'Configure AWS profile'


### PR DESCRIPTION
## Summary

This PR fixes `bin/remote exec` so the AWS command replaces the current process instead of running in a subshell, which allows interactive commands to run.

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->
