### PR TITLE
Notify slack only on failure

### DIFF
--- a/templates/.github/workflows/build.yml.tt
+++ b/templates/.github/workflows/build.yml.tt
@@ -34,7 +34,7 @@ jobs:
     name: Send Slack notification
     uses: infinum/devops-pipelines/.github/workflows/slack-notification.yml@v1.12.7
     needs: build-test-image-and-run-checks
-    if: ${{ needs.build-test-image-and-run-checks.result == 'failure' }}
+    if: ${{ failure() && needs.build-test-image-and-run-checks.result == 'failure' }}
     with:
       outcome: ${{ needs.build-test-image-and-run-checks.result }}
       channel: product-<%= app_name %>-notifications

--- a/templates/.github/workflows/build.yml.tt
+++ b/templates/.github/workflows/build.yml.tt
@@ -34,7 +34,7 @@ jobs:
     name: Send Slack notification
     uses: infinum/devops-pipelines/.github/workflows/slack-notification.yml@v1.12.7
     needs: build-test-image-and-run-checks
-    if: ${{ always() }}
+    if: ${{ needs.build-test-image-and-run-checks.result == 'failure' }}
     with:
       outcome: ${{ needs.build-test-image-and-run-checks.result }}
       channel: product-<%= app_name %>-notifications


### PR DESCRIPTION
## Summary
Currently the way build yml template is setup, slack notify job will always notify on slack.
For builds, outside of failures, we mostly do not care about the result, as such we should only be notifying slack in case of a failure
<!-- 
    Provide an overview of what this pull request aims to address or achieve.
-->

**Related issue**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. -->None

## Changes

### Type

- [x] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->
Change the if clause in slack notify jobs inside build.yml to only be fulfilled in case the results of the previous job is failed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->
Reason behind the way this was implemented: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#failure-with-conditions
