### PR TITLE
[Task #N/A] Add fail-level option to rubocop autocorrect command

### DIFF
--- a/recipes/run_generators.rb
+++ b/recipes/run_generators.rb
@@ -14,4 +14,4 @@ append_to_file 'lib/tasks/auto_annotate_models.rake', after: "its thing in produ
 end
 append_to_file 'lib/tasks/auto_annotate_models.rake', '# rubocop:enable Metrics/BlockLength, Rails/RakeEnvironment'
 rails_command 'generate strong_migrations:install'
-run 'bundle exec rubocop -A'
+run 'bundle exec rubocop -A --fail-level error'

--- a/recipes/run_generators.rb
+++ b/recipes/run_generators.rb
@@ -14,4 +14,4 @@ append_to_file 'lib/tasks/auto_annotate_models.rake', after: "its thing in produ
 end
 append_to_file 'lib/tasks/auto_annotate_models.rake', '# rubocop:enable Metrics/BlockLength, Rails/RakeEnvironment'
 rails_command 'generate strong_migrations:install'
-run 'bundle exec rubocop -A --fail-level error'
+run 'bundle exec rubocop -A --fail-level=error --format=quiet'


### PR DESCRIPTION
## Summary

<!-- 
    Provide an overview of what this pull request aims to address or achieve.
-->

When `rubocop -A `is run, in case there are uncorrectable offenses it returns 1 -> causing the setup to exit, and any commands that should be run after `rubocop -A` to be ignored; more specifically commit recipe is not applied.

**Related issue**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. -->None

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->

Add --fail-level error flag to the rubocop -A command, in order to make sure that rubocop returns 0 unless the severity of the fail is error or above

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->
Excerpt from the documentation:

> RuboCop exits with the following status codes:
> 0 if no offenses are found or if the severity of all offenses are less than --fail-level. (By default, if you use --autocorrect, offenses which are autocorrected do not cause RuboCop to fail.)
> 1 if one or more offenses equal or greater to --fail-level are found. (By default, this is any offense which is not autocorrected.)
> 2 if RuboCop terminates abnormally due to invalid configuration, invalid CLI options, or an internal error.

CLI flags link: https://docs.rubocop.org/rubocop/usage/basic_usage.html#command-line-flags
Documentation link to severity: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity
How rubocop evaluates severity levels: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity#level-instance_method -> more info in #level source code on the page