### PR TITLE
Fix/update gemfile generation and rubocop yml

### DIFF
--- a/recipes/gemfile.rb
+++ b/recipes/gemfile.rb
@@ -13,25 +13,19 @@ append_to_file 'Gemfile', after: /gem "rails".*\n/ do
     gem 'strong_migrations'
   HEREDOC
 end
-append_to_file 'Gemfile' do
+append_to_file 'Gemfile', after: /group :development do\n/ do
   <<~HEREDOC
-
-    group :development do
-      gem 'annotate'
-      gem 'better_errors'
-      gem 'binding_of_caller'
-      gem 'bullet'
-      gem 'overcommit', require: false
-      gem 'thor', require: false
-    end
+    gem 'annotate'
+    gem 'better_errors'
+    gem 'binding_of_caller'
+    gem 'bullet'
+    gem 'overcommit', require: false
+    gem 'thor', require: false
   HEREDOC
 end
-append_to_file 'Gemfile' do
+append_to_file 'Gemfile', after: /group :test do\n/ do
   <<~HEREDOC
-
-    group :test do
-      gem 'rspec-rails'
-    end
+    gem 'rspec-rails'
   HEREDOC
 end
 append_to_file 'Gemfile' do

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -1,4 +1,1 @@
-inherit_gem:
-  rubocop-infinum: rubocop.yml
-
-require: rubocop-infinum
+plugins: rubocop-infinum


### PR DESCRIPTION
## Summary
Fix rubocop issues regarding duplicated groups in Gemfile and rubocop-infinum plugin support.
<!-- 
    Provide an overview of what this pull request aims to address or achieve.
-->

**Related issue**:  <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. --> None

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->
It looks like the 'rails new' command adds development and test groups by default, so the process of adding another gems in these groups should be updated. Also, rubocop.yml has been updated because of changes in the rubocop-infinum gem regarding using plugins.

## Checklist

- [x ] I have performed a self-review of my own code.
- [ x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->
