### PR TITLE
Remove GitHub Actions PR paths-ignore filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,6 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - '.github/**'
-      - '**.md'
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Remove `paths-ignore` filter from the `build` workflow. `build` workflow is added to required status checks before merging the PR into the `main` branch. There is an edge case with this configuration, if PR modifies only the files listed in the `paths-ignore` filter, `build` workflow won't be triggered and the PR will never qualify for the merging with the `main` branch.

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [x] **Other**: This pull request makes other changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).