### PR TITLE
[Task #1134] Skip starting intermediate services

### DIFF
--- a/templates/compose.yml.tt
+++ b/templates/compose.yml.tt
@@ -1,39 +1,35 @@
 name: <%= app_name %>
 
+x-backend: &backend
+  build:
+    args:
+      RUBY_VERSION: <%= RUBY_VERSION %><% if uses_node? %>
+      NODE_VERSION: <%= node_version %><% end %>
+      DEBIAN_FRONTEND: noninteractive
+    target: dev
+  stdin_open: true
+  tty: true
+  volumes:
+    - .:/app:cached
+    - rails_cache:/app/tmp/cache
+    - bundle:/usr/local/bundle
+    - $HOME/.aws:/root/.aws
+  environment:<% if uses_pg? %>
+    DATABASE_HOST: postgres
+    DATABASE_USERNAME: postgres
+    DATABASE_PASSWORD: postgres
+    DATABASE_NAME: <%= app_name %>
+    DATABASE_PORT: 5432<% end %>
+    SIDEKIQ_REDIS_URL: redis://redis:6379/
+    WEB_CONCURRENCY: ${WEB_CONCURRENCY:-0}
+    HISTFILE: /app/log/.bash_history
+    PSQL_HISTFILE: /app/log/.psql_history
+    EDITOR: vim
+  depends_on:<% if uses_pg? %>
+    - postgres<% end %>
+    - redis
+
 services:
-  app: &app
-    build:
-      args:
-        RUBY_VERSION: <%= RUBY_VERSION %><% if uses_node? %>
-        NODE_VERSION: <%= node_version %><% end %>
-        DEBIAN_FRONTEND: noninteractive
-      target: dev
-      dockerfile: Dockerfile
-
-  backend: &backend
-    <<: *app
-    stdin_open: true
-    tty: true
-    volumes:
-      - .:/app:cached
-      - rails_cache:/app/tmp/cache
-      - bundle:/usr/local/bundle
-      - $HOME/.aws:/root/.aws
-    environment:<% if uses_pg? %>
-      DATABASE_HOST: postgres
-      DATABASE_USERNAME: postgres
-      DATABASE_PASSWORD: postgres
-      DATABASE_NAME: <%= app_name %>
-      DATABASE_PORT: 5432<% end %>
-      SIDEKIQ_REDIS_URL: redis://redis:6379/
-      WEB_CONCURRENCY: ${WEB_CONCURRENCY:-0}
-      HISTFILE: /app/log/.bash_history
-      PSQL_HISTFILE: /app/log/.psql_history
-      EDITOR: vim
-    depends_on:<% if uses_pg? %>
-      - postgres<% end %>
-      - redis
-
   runner:
     <<: *backend
     command: /bin/bash


### PR DESCRIPTION
## Summary

Intermediate services (`app`, `backend`), that are used to dry-up service definitions for other backend-based services, are started as containers when stack is started with `docker compose up`. The proposed solution uses [extension](https://github.com/compose-spec/compose-spec/blob/main/spec.md#extension) feature to extract intermediate service configuration outside of the `services` top-level element.

**Related issue**: [#1134](https://app.productive.io/1-infinum/projects/2274/tasks/task/13442412?board=268199&filter=MjU5ODE4)

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [x] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).