### PR TITLE
[Task #1151] Don't skip bundle install

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -15,12 +15,12 @@ class CLI
     parse_options
 
     FileUtils.chdir(File.expand_path('../tmp', __dir__)) do
-      FileUtils.rmtree('demo') if File.directory?('demo')
-      if system('docker volume inspect demo_postgres > /dev/null 2>&1')
-        system('docker volume rm demo_postgres > /dev/null 2>&1')
+      if File.directory?('demo')
+        system('docker compose -f demo/compose.yml run --rm runner bundle exec rake db:drop')
+        FileUtils.rmtree('demo')
       end
 
-      system("rails new demo --api --database=postgresql --template=#{template}")
+      system("rails new demo --api --database=postgresql --template=#{template} --force")
     end
   end
 


### PR DESCRIPTION
## Summary

Remove option to skip `bundle install` when testing the template with `bin/run`.

**Related issue**: [#1151](https://app.productive.io/1-infinum/projects/2274/tasks/task/13619164?board=268199&filter=MjA2MTY2)

## Changes

### Type

- [x] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

Delete databases stored on docker volume if set on a previous `bin/run`. When running `bin/run` multiple times, previously ran flipper migrations store DB tables on the mounted volume, but migration timestamps (previous <> current template run) don't match, so active record runs the migrations which then fail on DB table name collision. It's not a perfect solution, I've already identified a use-case with `git worktree` where it doesn't work on the first run, but it does cover majority of common usage.

Added `--force` flag to automatically overwrite existing files.