### PR TITLE
Update to deployment-pipelines v3

### DIFF
--- a/templates/.github/workflows/deploy-production.yml
+++ b/templates/.github/workflows/deploy-production.yml
@@ -17,4 +17,6 @@ jobs:
         subnet-0xFF
       # TODO: replace with actual security group IDs (coordinate with DevOps)
       security_group_ids: sg-0xFF
+      # TODO: Update according to the trigger used
+      git_ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     secrets: inherit

--- a/templates/.github/workflows/deploy-staging.yml
+++ b/templates/.github/workflows/deploy-staging.yml
@@ -17,4 +17,6 @@ jobs:
         subnet-0xFF
       # TODO: replace with actual security group IDs (coordinate with DevOps)
       security_group_ids: sg-0xFF
+      # TODO: Update according to the trigger used
+      git_ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     secrets: inherit

--- a/templates/.github/workflows/deploy.yml.tt
+++ b/templates/.github/workflows/deploy.yml.tt
@@ -15,6 +15,10 @@ on:
         description:  List of security group IDs for the ECS task
         required: true
         type: string
+      git_ref:
+        description: Git revision to checkout for build and deployment steps. Also used as image tag.
+        required: true
+        type: string
 
 jobs:
   context:
@@ -27,8 +31,6 @@ jobs:
       aws_ecr_region: ${{ steps.get.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ steps.get.outputs.aws_ecr_account_id }}
       aws_ecs_cluster: ${{ steps.get.outputs.aws_ecs_cluster }}
-      # TODO: Update according to the trigger used
-      git_revision: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
       - id: get
         run: |
@@ -45,14 +47,14 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
       cloud: AWS
-      tags: ${{ needs.context.outputs.aws_ecr_uri }}:${{ needs.context.outputs.git_revision }}
+      tags: ${{ needs.context.outputs.aws_ecr_uri }}:${{ inputs.git_ref }}
       aws_region: ${{ needs.context.outputs.aws_region }}
       aws_ecr_region: ${{ needs.context.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ needs.context.outputs.aws_ecr_account_id }}
       target: deploy
       secret_files: |
         app-secrets=sample.env
-      git_ref: ${{ needs.context.outputs.git_revision }}
+      git_ref: ${{ inputs.git_ref }}
     secrets: inherit
 
   deploy-migrations:
@@ -64,7 +66,7 @@ jobs:
       aws_region: ${{ needs.context.outputs.aws_region }}
       ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
       task_definition_path: infra/ecs/task-definition-app-${{ inputs.environment }}.json
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ needs.context.outputs.git_revision }}
+      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ inputs.git_ref }}
       container_name: <%= app_name %>
       override_container_name: <%= app_name %>
       override_container_command: |
@@ -74,7 +76,7 @@ jobs:
         db:migrate
       subnet_ids: ${{ inputs.subnet_ids }}
       security_group_ids: ${{ inputs.security_group_ids }}
-      git_ref: ${{ needs.context.outputs.git_revision }}
+      git_ref: ${{ inputs.git_ref }}
     secrets: inherit
 
   deploy-backend:
@@ -82,14 +84,14 @@ jobs:
     uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v3.0.0
     needs: [context, deploy-migrations]
     with:
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ needs.context.outputs.git_revision }}
+      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ inputs.git_ref }}
       environment: ${{ inputs.environment }}
       aws_region: ${{ needs.context.outputs.aws_region }}
       ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
       ecs_service: <%= app_name %>
       task_def_path: infra/ecs/task-definition-app-${{ inputs.environment }}.json
       container_name: <%= app_name %>
-      git_ref: ${{ needs.context.outputs.git_revision }}
+      git_ref: ${{ inputs.git_ref }}
     secrets: inherit
 
   deploy-background-job-processor:
@@ -97,14 +99,14 @@ jobs:
     uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v3.0.0
     needs: [context, deploy-migrations]
     with:
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ needs.context.outputs.git_revision }}
+      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ inputs.git_ref }}
       environment: ${{ inputs.environment }}
       aws_region: ${{ needs.context.outputs.aws_region }}
       ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
       ecs_service: <%= app_name %>-sidekiq
       task_def_path: infra/ecs/task-definition-sidekiq-${{ inputs.environment }}.json
       container_name: <%= app_name %>-sidekiq
-      git_ref: ${{ needs.context.outputs.git_revision }}
+      git_ref: ${{ inputs.git_ref }}
     secrets: inherit
 
   deployment-status:

--- a/templates/.github/workflows/deploy.yml.tt
+++ b/templates/.github/workflows/deploy.yml.tt
@@ -27,6 +27,8 @@ jobs:
       aws_ecr_region: ${{ steps.get.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ steps.get.outputs.aws_ecr_account_id }}
       aws_ecs_cluster: ${{ steps.get.outputs.aws_ecs_cluster }}
+      # TODO: Update according to the trigger used
+      git_revision: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
       - id: get
         run: |
@@ -38,30 +40,31 @@ jobs:
 
   build-deploy-image-and-push:
     name: Build deploy image and push to registry
-    uses: infinum/devops-pipelines/.github/workflows/docker-build-push.yml@v1.13.0
+    uses: infinum/devops-pipelines/.github/workflows/docker-build-push.yml@v3.0.0
     needs: context
     with:
       environment: ${{ inputs.environment }}
       cloud: AWS
-      tags: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
+      tags: ${{ needs.context.outputs.aws_ecr_uri }}:${{ needs.context.outputs.git_revision }}
       aws_region: ${{ needs.context.outputs.aws_region }}
       aws_ecr_region: ${{ needs.context.outputs.aws_ecr_region }}
       aws_ecr_account_id: ${{ needs.context.outputs.aws_ecr_account_id }}
       target: deploy
       secret_files: |
         app-secrets=sample.env
+      git_ref: ${{ needs.context.outputs.git_revision }}
     secrets: inherit
 
   deploy-migrations:
     name: Deploy migrations
-    uses: infinum/devops-pipelines/.github/workflows/ecs-run-task.yml@v1.13.0
+    uses: infinum/devops-pipelines/.github/workflows/ecs-run-task.yml@v3.0.0
     needs: [context, build-deploy-image-and-push]
     with:
       environment: ${{ inputs.environment }}
       aws_region: ${{ needs.context.outputs.aws_region }}
       ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
       task_definition_path: infra/ecs/task-definition-app-${{ inputs.environment }}.json
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
+      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ needs.context.outputs.git_revision }}
       container_name: <%= app_name %>
       override_container_name: <%= app_name %>
       override_container_command: |
@@ -71,34 +74,37 @@ jobs:
         db:migrate
       subnet_ids: ${{ inputs.subnet_ids }}
       security_group_ids: ${{ inputs.security_group_ids }}
+      git_ref: ${{ needs.context.outputs.git_revision }}
     secrets: inherit
 
   deploy-backend:
     name: Deploy backend
-    uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v1.13.0
+    uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v3.0.0
     needs: [context, deploy-migrations]
     with:
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
+      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ needs.context.outputs.git_revision }}
       environment: ${{ inputs.environment }}
       aws_region: ${{ needs.context.outputs.aws_region }}
       ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
       ecs_service: <%= app_name %>
       task_def_path: infra/ecs/task-definition-app-${{ inputs.environment }}.json
       container_name: <%= app_name %>
+      git_ref: ${{ needs.context.outputs.git_revision }}
     secrets: inherit
 
   deploy-background-job-processor:
     name: Deploy background job processor
-    uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v1.13.0
+    uses: infinum/devops-pipelines/.github/workflows/deploy-ecs-task-definition.yml@v3.0.0
     needs: [context, deploy-migrations]
     with:
-      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ github.sha }}
+      image_uri: ${{ needs.context.outputs.aws_ecr_uri }}:${{ needs.context.outputs.git_revision }}
       environment: ${{ inputs.environment }}
       aws_region: ${{ needs.context.outputs.aws_region }}
       ecs_cluster: ${{ needs.context.outputs.aws_ecs_cluster }}
       ecs_service: <%= app_name %>-sidekiq
       task_def_path: infra/ecs/task-definition-sidekiq-${{ inputs.environment }}.json
       container_name: <%= app_name %>-sidekiq
+      git_ref: ${{ needs.context.outputs.git_revision }}
     secrets: inherit
 
   deployment-status:

--- a/templates/SETUP.md
+++ b/templates/SETUP.md
@@ -24,14 +24,14 @@ on:
       - completed
 ```
 
-**Be aware** that different triggers set `GITHUB_SHA` and `GITHUB_REF` values differently in the executing action. To prevent issues with incorrect code revision being checked out for the common `workflow_run` trigger a default way to determine the correct SHA to checkout is defined in `.github/workflows/deploy.yml` :
+**Be aware** that different triggers set `GITHUB_SHA` and `GITHUB_REF` values differently in the executing action. To prevent issues with incorrect code revision being checked out for the common `workflow_run` trigger, a default way to determine the correct SHA to checkout is defined in `.github/workflows/deploy-<env>.yml`:
 
 ```yaml
 jobs:
-  context:
-    name: Setup context
-    outputs:
-      git_revision: ${{ github.event.workflow_run.head_sha || github.sha }}
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      git_ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 ```
 
 This value is then passed as an explicit `git_ref` to the build and deployment reusable actions.

--- a/templates/SETUP.md
+++ b/templates/SETUP.md
@@ -7,6 +7,33 @@ To complete project setup from this template, complete the following steps:
 - [ ] Update `README.md`
 - [ ] Update infrastructure concerns in coordination with the DevOps team
     - [ ] Specify ECS task definitions (`/infra/ecs/*`)
-    - [ ] Update ECS deployment configuration (`.github/workflows/deploy-*`)
+    - [ ] Update ECS deployment configuration (`.github/workflows/deploy-*`).
+    - [ ] Review [action triggers gotchas](#github-actions-triggers).
 - [ ] Review and resolve `TODO` comments
 - [ ] Delete the `SETUP.md` file
+
+#### Github Actions trigger gotchas
+
+You will likely enable automatic deployments using the [workflow_run](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run) trigger when CI checks complete:
+
+```yaml
+on:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
+```
+
+**Be aware** that different triggers set `GITHUB_SHA` and `GITHUB_REF` values differently in the executing action. To prevent issues with incorrect code revision being checked out for the common `workflow_run` trigger a default way to determine the correct SHA to checkout is defined in `.github/workflows/deploy.yml` :
+
+```yaml
+jobs:
+  context:
+    name: Setup context
+    outputs:
+      git_revision: ${{ github.event.workflow_run.head_sha || github.sha }}
+```
+
+This value is then passed as an explicit `git_ref` to the build and deployment reusable actions.
+
+Review the docs carefully for the triggers you have chosen and update accordingly.


### PR DESCRIPTION
## Summary

Reusable image build and deployment actions use `actions/checkout`. Depending on the workflow trigger used this action may unexpectedly checkout default branch HEAD.

**Related issue**: [#1192](https://app.productive.io/1-infinum/tasks/14091509)

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

- updated to use `v3.0.0` deployment pipelines which add mandatory `git_ref` input
- resolve correct git revision for the common use case (`workflow_run` trigger) and
  - use it as image tag
  - pass it to deployment actions
- added TODOs and short docs explaining the GHA trigger gotchas

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->
